### PR TITLE
Add recovery state

### DIFF
--- a/adb/device_state.go
+++ b/adb/device_state.go
@@ -1,12 +1,18 @@
 package adb
 
-import "github.com/evrins/goadb/internal/errors"
+import (
+	"log"
+
+	"github.com/evrins/goadb/internal/errors"
+)
 
 // DeviceState represents one of the 3 possible states adb will report devices.
 // A device can be communicated with when it's in StateOnline.
 // A USB device will make the following state transitions:
-// 	Plugged in: StateDisconnected->StateOffline->StateOnline
-// 	Unplugged:  StateOnline->StateDisconnected
+//
+//	Plugged in: StateDisconnected->StateOffline->StateOnline
+//	Unplugged:  StateOnline->StateDisconnected
+//
 //go:generate stringer -type=DeviceState
 type DeviceState int8
 
@@ -15,6 +21,7 @@ const (
 	StateDisconnected
 	StateOffline
 	StateOnline
+	StateRecovery
 	StatUnauthorized
 )
 
@@ -22,6 +29,7 @@ var deviceStateStrings = map[string]DeviceState{
 	"":             StateDisconnected,
 	"offline":      StateOffline,
 	"device":       StateOnline,
+	"recovery":     StateRecovery,
 	"unauthorized": StatUnauthorized,
 }
 
@@ -30,5 +38,6 @@ func parseDeviceState(str string) (DeviceState, error) {
 	if !ok {
 		return StateInvalid, errors.Errorf(errors.ParseError, "invalid device state: %q", state)
 	}
+	log.Println(str)
 	return state, nil
 }

--- a/adb/devicestate_string.go
+++ b/adb/devicestate_string.go
@@ -4,9 +4,9 @@ package adb
 
 import "fmt"
 
-const _DeviceState_name = "StateInvalidStateDisconnectedStateOfflineStateOnline"
+const _DeviceState_name = "StateInvalidStateDisconnectedStateOfflineStateOnlineStateRecovery"
 
-var _DeviceState_index = [...]uint8{0, 12, 29, 41, 52}
+var _DeviceState_index = [...]uint8{0, 12, 29, 41, 52, 65}
 
 func (i DeviceState) String() string {
 	if i < 0 || i >= DeviceState(len(_DeviceState_index)-1) {


### PR DESCRIPTION
If device in recovery, `device.State()` will return `adb.StateRecovery` instead of `adb.StateInvalid`